### PR TITLE
[Loggable] Added support for Doctrine attribute override with XML mapping

### DIFF
--- a/lib/Gedmo/Loggable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Xml.php
@@ -63,6 +63,12 @@ class Xml extends BaseXml
         if (isset($xmlDoctrine->{'embedded'})) {
             $this->inspectElementForVersioned($xmlDoctrine->{'embedded'}, $config, $meta);
         }
+        
+        if ($xmlDoctrine->{'attribute-overrides'}->count() > 0) {
+            if ($xmlDoctrine->{'attribute-overrides'}->count() > 0) {
+                $this->inspectElementForVersioned($xmlDoctrine->{'attribute-overrides'}->{'attribute-override'}, $config, $meta);
+            }
+        }
 
         if (!$meta->isMappedSuperclass && $config) {
             if (is_array($meta->identifier) && count($meta->identifier) > 1) {


### PR DESCRIPTION
Added support for the XML  `attribute-overrides` mapping (in the same fashion #1448 did for YAML).

I reckon it's a bit weird though, because it works with this syntax...

```xml
<attribute-overrides>
    <attribute-override name="phone">
        <field  type="string" column="phone" length="64" nullable="true"/>
        <gedmo:versioned/>
    </attribute-override>
</attribute-overrides>
```

... instead of this one:

```xml
<attribute-overrides>
    <attribute-override name="phone">
        <field  type="string" column="phone" length="64" nullable="true">
            <gedmo:versioned/>
        </field>
    </attribute-override>
</attribute-overrides>
```
